### PR TITLE
Add :break op

### DIFF
--- a/doc/extensibility.md
+++ b/doc/extensibility.md
@@ -27,6 +27,10 @@ Supports alternative "inline" text besides a single space.
 
 `:line` is shorthand for `[:line " "]`.
 
+### :break
+
+Force a newline. The current indentation level is preserved.
+
 ### :group
 
 Just like Swierstra and Chitil.

--- a/src/bbloom/fipp/printer.clj
+++ b/src/bbloom/fipp/printer.clj
@@ -45,6 +45,9 @@
     (assert (string? inline))
     [{:op :line, :inline inline}]))
 
+(defmethod serialize-node :break [& _]
+  [{:op :break}])
+
 (defmethod serialize-node :group [[_ & children]]
   (concat [{:op :begin}] (serialize children) [{:op :end}]))
 
@@ -168,6 +171,10 @@
               (let [inline (:inline node)
                     state* (update-in state [:column] + (count inline))]
                 [state* [inline]]))
+          :break
+            (let [state* (assoc state :length (- (+ right *width*) indent)
+                                      :column 0)]
+              [state* ["\n"]])
           :nest
             [(update-in state [:tab-stops] conj (+ indent (:offset node))) nil]
           :align


### PR DESCRIPTION
The :break op forces a newline regardless of whether the line fits or
not. The current tabstop is preserved.
