### PR TITLE
Passthru op

### DIFF
--- a/doc/extensibility.md
+++ b/doc/extensibility.md
@@ -14,6 +14,10 @@ Just like Swierstra and Chitil.
 
 Strings expand to [:text ...] nodes.
 
+### :pass
+
+Arguments are passed through and printed verbatim. Ex. `[:pass ...]`.
+
 ### :span
 
 A variadic version of binary document composition.

--- a/src/bbloom/fipp/printer.clj
+++ b/src/bbloom/fipp/printer.clj
@@ -37,6 +37,9 @@
 (defmethod serialize-node :text [[_ & text]]
   [{:op :text, :text (apply str text)}])
 
+(defmethod serialize-node :pass [[_ & text]]
+  [{:op :pass, :text (apply str text)}])
+
 (defmethod serialize-node :span [[_ & children]]
   (serialize children))
 
@@ -163,6 +166,8 @@
                   [state* emit])
                 (let [state* (update-in state [:column] + (count text))]
                   [state* [text]])))
+          :pass
+            [state [(:text node)]]
           :line
             (if (zero? fits)
               (let [state* (assoc state :length (- (+ right *width*) indent)
@@ -254,5 +259,19 @@
          )
     ;nil
     )
+
+  ;; test of :pass op
+  (do
+    (pprint-document
+      [:group "AB" :line "B" :line "C"]
+      {:width 6}) 
+    (println "--")
+    (pprint-document
+      [:group "<AB>" :line "B" :line "C"]
+      {:width 6}) 
+    (println "--")
+    (pprint-document
+      [:group [:pass "<"] "AB" [:pass ">"] :line "B" :line "C"]
+      {:width 6})) 
 
 )


### PR DESCRIPTION
The :pass op (usage: [:pass "foo" "bar" ...]) concatenates its arguments
and passes them through the formatter verbatim (they do not affect width
or formatting calculations). This is useful for adding zero-width ANSI
escape codes to the printed output, for example.
