### PR TITLE
Pretty Printing of 'nil'

### DIFF
--- a/src/fipp/edn.clj
+++ b/src/fipp/edn.clj
@@ -22,6 +22,10 @@
 
 (extend-protocol IPretty
 
+  nil
+  (-pretty [x]
+    [:text "nil"])
+
   java.lang.Object
   (-pretty [x]
     [:text (pr-str x)])


### PR DESCRIPTION
Fix for Exception thrown when trying to `pprint` a value containing `nil`:

``` clojure
(fipp.edn/pprint nil)
; => IllegalArgumentException No implementation of method: :-pretty of 
;    protocol: #'fipp.edn/IPretty found for class: nil  clojure.core/
;    -cache-protocol-fn (core_deftype.clj:541)

(fipp.edn/pprint {:a nil})
; => IllegalArgumentException No implementation of method: :-pretty of 
;    protocol: #'fipp.edn/IPretty found for class: nil  clojure.core/
;    -cache-protocol-fn (core_deftype.clj:541)
```

(Broke some code for me after switching from `0.1.0-SNAPSHOT` to `0.3.0-SNAPSHOT`.)
