### PR TITLE
Updated dependencies, consl → conjl

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,6 +3,6 @@
   :url "https://github.com/brandonbloom/fipp"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.5.1"]
-                 [org.clojure/data.finger-tree "0.0.1"]
+  :dependencies [[org.clojure/clojure "1.6.0"]
+                 [org.clojure/data.finger-tree "0.0.2"]
                  [transduce "0.1.0"]])

--- a/src/fipp/printer.clj
+++ b/src/fipp/printer.clj
@@ -3,7 +3,7 @@
   Lazy v. Yield: Incremental, Linear Pretty-printing"
   (:require [clojure.string :as s]
             [clojure.core.reducers :as r]
-            [clojure.data.finger-tree :refer (double-list consl ft-concat)]
+            [clojure.data.finger-tree :as ftree :refer (double-list ft-concat)]
             [transduce.reducers :as t]))
 
 
@@ -11,7 +11,7 @@
 
 (def empty-deque (double-list))
 
-(def conjl (fnil consl empty-deque))
+(def conjl (fnil ftree/conjl empty-deque))
 (def conjr (fnil conj empty-deque))
 
 (defn conjlr [l deque r]


### PR DESCRIPTION
Dependencies updated:
clojure.data.finger-tree 0.0.1 → 0.0.2
clojure 1.5.1 → 1.6.0
