### PR TITLE
add :escaped node type

### DIFF
--- a/doc/primitives.md
+++ b/doc/primitives.md
@@ -21,6 +21,14 @@ automatically expanded to `[:text "..."]`.
 You should not include `\n` characters in text.
 
 
+## [:escaped "..."]
+
+Escaped nodes are printed verbatim, but measure as one character.
+
+Useful for cases where characters need to be escaped in the printed
+output, but will eventually be rendered to occupy only one column.
+
+
 ## [:pass "..."]
 
 Passthrough nodes are printed verbaitm, but *not* measured.

--- a/test/fipp/printer_test.clj
+++ b/test/fipp/printer_test.clj
@@ -131,3 +131,14 @@
     (is (= (ppstr doc1 3) "A\nB C\n"))
     (is (= (ppstr doc1 2) "A\nB\nC\n"))
     (is (= (ppstr doc1 1) "A\nB\nC\n"))))
+
+(deftest escaped-test
+  (testing "escaped nodes output verbatim, have width 1"
+    (is (= (ppstr [:group (repeat 5 [:span "a" :line])] 9)
+           (str (apply str (repeat 5 "a\n")) "\n")))
+    (is (= (ppstr [:group (repeat 5 [:span "a" :line])] 10)
+           (str (apply str (repeat 5 "a ")) "\n")))
+    (is (= (ppstr [:group (repeat 5 [:span [:escaped "&#97;"] :line])] 9)
+           (str (apply str (repeat 5 "&#97;\n")) "\n")))
+    (is (= (ppstr [:group (repeat 5 [:span [:escaped "&#97;"] :line])] 10)
+           (str (apply str (repeat 5 "&#97; ")) "\n")))))


### PR DESCRIPTION
from the commit:
> an escaped node prints its single argument verbatim but measures it as
> only one character. this is useful for allowing multi-character escape
> sequences in the printed output to represent a single character. For
> example, html entities such as "&amp;quot;" or "&amp;amp;".

Thanks for the great work! I needed something between `:pass` and `:text` while working on extending `puget` to use HTML markup for colorizing. Please consider this pull request to add `:escaped`.