### PR TITLE
Separate records into separate visitor function

### DIFF
--- a/src/fipp/edn.cljc
+++ b/src/fipp/edn.cljc
@@ -1,7 +1,7 @@
 (ns fipp.edn
   "Provides a pretty document serializer and pprint fn for Clojure/EDN forms.
   See fipp.clojure for pretty printing Clojure code."
-  (:require [fipp.ednize :refer [edn]]
+  (:require [fipp.ednize :refer [edn record->tagged]]
             [fipp.visit :refer [visit visit*]]
             [fipp.engine :refer (pprint-document)]))
 
@@ -70,6 +70,8 @@
   (visit-pattern [this x]
     [:text (pr-str x)])
 
+  (visit-record [this x]
+    (visit this (record->tagged x)))
 
   )
 

--- a/src/fipp/visit.cljc
+++ b/src/fipp/visit.cljc
@@ -25,7 +25,7 @@
   (visit-meta [this meta x])
   (visit-var [this x])
   (visit-pattern [this x])
-
+  (visit-record [this x])
   )
 
 ;;TODO: CLJ-1719 and CLJS-1241
@@ -51,7 +51,7 @@
     (number? x) (visit-number visitor x)
     (seq? x) (visit-seq visitor x)
     (vector? x) (visit-vector visitor x)
-    (record? x) (visit-tagged visitor (i/record->tagged x))
+    (record? x) (visit-record visitor x)
     (map? x) (visit-map visitor x)
     (set? x) (visit-set visitor x)
     (tagged-literal? x) (visit-tagged visitor x)

--- a/src/fipp/visit.cljc
+++ b/src/fipp/visit.cljc
@@ -1,6 +1,5 @@
 (ns fipp.visit
-  "Convert to and visit edn structures."
-  (:require [fipp.ednize :as i]))
+  "Convert to and visit edn structures.")
 
 ;;;TODO Stablize public interface
 


### PR DESCRIPTION
Hey @brandonbloom, I ran into an issue which could benefit from this change. The new code in Puget adds a `CanonicalPrinter` which implements `IVisitor`. This printer should throw an exception if it encounters any type without an explicitly-defined print handler. It does this by throwing an error if `visit-unknown` is called. You can probably see where this is going - record types are automatically rendered by the current code as a tagged-literal, even though no such extension has been added by the printer.

This change preserves the existing behaviour, but allows implementing printers to choose what they want to do with records in `visit-record` instead of creating tagged literals automatically.

Not a blocker, since I can get around this in my code by wrapping `visit*`, checking for `record?`, explicitly dispatching to `visit-unknown` instead, and then in `visit-unknown` checking again for `record?` to generate the standard tagged-literal representation if desired. It would be nicer not to need this workaround, though. :)