### PR TITLE
Add :print-length and :print-level options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ pom.xml*
 *.class
 .lein-*
 /out
+.benchmark-samples

--- a/project.clj
+++ b/project.clj
@@ -5,4 +5,6 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.7.0-beta2"]
                  [org.clojure/core.rrb-vector "0.0.11"]]
-  :profiles {:dev {:dependencies [[criterium "0.4.3"]]}})
+  :profiles {:dev {:dependencies [[criterium "0.4.3"]
+                                  [org.clojure/test.check "0.9.0"]
+                                  [org.clojure/tools.reader "1.0.0-alpha2"]]}})

--- a/test/fipp/benchmark.clj
+++ b/test/fipp/benchmark.clj
@@ -1,26 +1,42 @@
 (ns fipp.benchmark
-  (:require [clojure.pprint]
+  (:require [fipp.clojure]
             [fipp.edn]
-            [fipp.clojure]
-            [criterium.core :refer [bench]]))
+            [clojure.java.io :as io]
+            [clojure.pprint]
+            [clojure.test.check.generators :as gen]
+            [clojure.tools.reader.edn :as edn]
+            [criterium.core :refer [bench]])
+  (:import [java.io File Writer]))
 
-(def benched-fns [
-  ;prn
-  fipp.edn/pprint
-  fipp.clojure/pprint
-  ;clojure.pprint/pprint
-])
+(set! *warn-on-reflection* true)
 
-(def samples {
-  :long (vec (range 10000))
-  ;; Dirty hacky source of test data:
-  :mixed (read-string {:read-cond :allow} (str "[" (slurp "src/fipp/engine.cljc") "]"))
-})
+(def benched-fns [prn
+                  fipp.edn/pprint
+                  fipp.clojure/pprint
+                  clojure.pprint/pprint])
+
+(def writer
+  (proxy [Writer] []
+    (write [_])
+    (flush [])
+    (close [])))
+
+(defn samples []
+  (let [^File file (io/file ".benchmark-samples")]
+    (when-not (.exists file)
+      (spit file (with-out-str
+                   (fipp.edn/pprint (gen/sample gen/any-printable 1000)))))
+
+    (edn/read-string (slurp file))))
 
 ;; lein run -m fipp.benchmark
 (defn -main []
-  (doseq [f benched-fns
-          [k v] samples]
-    (println "Testing " f " on " k)
-    (criterium.core/with-progress-reporting
-      (bench (with-out-str (f v))))))
+  (let [samples (samples)]
+    (doseq [f benched-fns]
+      (println "Benchmarking " f)
+      (time
+       (bench
+        (binding [*out* writer]
+          (doseq [sample samples]
+            (f sample)))))
+      (println))))

--- a/test/fipp/edn_test.clj
+++ b/test/fipp/edn_test.clj
@@ -123,6 +123,19 @@
            "{:a 0, :b 1, :c 2 ...}\n"))
     (is (= (with-out-str (pprint (into (sorted-set) [0 1 2 3]) {:print-length 3}))
            "#{0 1 2 ...}\n")))
+  (testing ":print-level option"
+    (is (= (with-out-str (pprint '(:a (:b (:c (:d)))) {:print-level 3}))
+           "(:a (:b (:c (#))))\n"))
+    (is (= (with-out-str (pprint '(:a (:b (:c (:d) :e) :f) :g) {:print-level 3}))
+           "(:a (:b (:c (#) :e) :f) :g)\n"))
+    (is (= (with-out-str (pprint [:a [:b [:c [:d]]]] {:print-level 3}))
+           "[:a [:b [:c [#]]]]\n"))
+    (is (= (with-out-str (pprint [:a [:b [:c [:d] :e] :f] :g] {:print-level 3}))
+           "[:a [:b [:c [#] :e] :f] :g]\n"))
+    (is (= (with-out-str (pprint (into (sorted-map) {:a {:b {:c {:d nil}}}}) {:print-level 3}))
+           "{:a {:b {:c {#}}}}\n"))
+    (is (= (with-out-str (pprint #{#{#{#{}}}} {:print-level 3}))
+           "#{#{#{#{#}}}}\n")))
   )
 
 (comment

--- a/test/fipp/edn_test.clj
+++ b/test/fipp/edn_test.clj
@@ -111,9 +111,9 @@
            "#foo ^{:x 1} []")))
   (testing "Not quite Edn"
     (is (= (with-out-str (pprint #'inc))
-           "#'clojure.core/inc\n")))
-    (is (= (with-out-str (pprint #"x\?y")
-           "#\"x\\?y\"")))
+           "#'clojure.core/inc\n"))
+    (is (= (with-out-str (pprint #"x\?y"))
+           "#\"x\\?y\"\n")))
   )
 
 (comment

--- a/test/fipp/edn_test.clj
+++ b/test/fipp/edn_test.clj
@@ -114,6 +114,15 @@
            "#'clojure.core/inc\n"))
     (is (= (with-out-str (pprint #"x\?y"))
            "#\"x\\?y\"\n")))
+  (testing ":print-length option"
+    (is (= (with-out-str (pprint (range 4) {:print-length 3}))
+           "(0 1 2 ...)\n"))
+    (is (= (with-out-str (pprint [0 1 2 3] {:print-length 3}))
+           "[0 1 2 ...]\n"))
+    (is (= (with-out-str (pprint (into (sorted-map) {:a 0 :b 1 :c 2 :d 3}) {:print-length 3}))
+           "{:a 0, :b 1, :c 2 ...}\n"))
+    (is (= (with-out-str (pprint (into (sorted-set) [0 1 2 3]) {:print-length 3}))
+           "#{0 1 2 ...}\n")))
   )
 
 (comment


### PR DESCRIPTION
Hi, first of all, thanks for the great (and _fast_!) library :-).

Both options are analogous to (and default to) `*print-length*` and `*print-level*` respectively.

I also took a stab at improving the benchmark, using `test.check` to generate sample data using `any-printable`. Additionally, I've switched to using a stubbed `Writer` implementation instead of `with-out-str` to try and minimise any overhead.

Here are results for the new benchmark, both [before](https://gist.github.com/cichli/2b99d646f72f0ddbb5e8) and [after](https://gist.github.com/cichli/01e5049ef3dd764555f2) this change is applied - the impact is reasonably negligible for normal usage (i.e. when `:print-length` / `:print-level` are not set). Please do try and verify these results locally!

Notes on the implementation:

* `:print-length` is implemented by using a `take` transducer to limit the number of lines returned by the relevant `visit-*` methods, iff `:print-length` is set.
* The string ` ...` is appended to the collection being printed if its length exceeds `:print-length`.

* `:print-level` is implemented similarly to in Clojure itself - each time we call one of the relevant `visit-*` methods, we decrement its value, iff `:print-level` is set. This is done by using a new instance of `EdnPrinter` rather than the dynamic binding approach used in Clojure.
* The string `#` is printed instead of the contents of the collection if the current `:print-level` is negative.

Motivation for this change: we now use `fipp` as the default pretty-printer in CIDER, but would like a way to prevent accidental printing of infinitely long or recursive structures :-). Let me know if there's anything I've missed or you think I should change.