### PR TITLE
Fix some seq retention issues

### DIFF
--- a/src/fipp/engine.cljc
+++ b/src/fipp/engine.cljc
@@ -5,6 +5,12 @@
             [fipp.deque :as deque]))
 
 
+(defn unchunk [s]
+  (when (seq s)
+    (lazy-seq
+     (cons (first s)
+           (unchunk (next s))))))
+
 ;;; Serialize document into a stream
 
 (defmulti serialize-node first)
@@ -12,7 +18,7 @@
 (defn serialize [doc]
   (cond
     (nil? doc) nil
-    (seq? doc) (mapcat serialize doc)
+    (seq? doc) (mapcat serialize (unchunk doc))
     (string? doc) [{:op :text, :text doc}]
     (keyword? doc) (serialize-node [doc])
     (vector? doc) (serialize-node doc)

--- a/src/fipp/engine.cljc
+++ b/src/fipp/engine.cljc
@@ -229,10 +229,9 @@
 (defn pprint-document [document options]
   (let [options (merge {:width 70} options)]
     (->> (serialize document)
-         (eduction
-           annotate-rights
-           (annotate-begins options)
-           (format-nodes options))
+         (sequence (comp annotate-rights
+                         (annotate-begins options)
+                         (format-nodes options)))
          (run! print)))
   (println))
 


### PR DESCRIPTION
I first discovered that

``` clojure
(binding [*print-length* 10]
  (fipp.edn/pprint (range)))
```

would never return, because we were comparing `print-length` to `(count xs)` - which is no good on an infinite sequence. Switched to using `(seq? (drop print-length xs))`, and added extra tests to ensure a) this works for infinite sequences and b) a potential off-by-one error has not been made.

Further poking around showed that the following would cause heap exhaustion:

``` clojure
(binding [*out* (proxy [java.io.Writer] []
                  (write [_])
                  (flush [])
                  (close []))]
  (fipp.edn/pprint (range 100000000)))
```

There were two places causing memory to leak:
- `serialize` used `mapcat`, which causes full realisation of chunked sequences (I think this is a bug in the `[xs ys & zs]` arity of `concat`; it seems `zs` is being rooted inside the `cat` closure. Not sure if there's a JIRA related to this but I'll take a look). Wrap `doc` in a call to `unchunk` to ensure the chunked sequence path is not taken in `concat`.
- `Eduction`s hold a reference to their `coll` field - switch to using `sequence`, which does not hold onto anything when used with `run!`.
