### PR TITLE
:nest :indent arg should default to 2

### DIFF
--- a/src/fipp/engine.cljc
+++ b/src/fipp/engine.cljc
@@ -45,10 +45,13 @@
 (defmethod serialize-node :group [[_ & children]]
   (concat [{:op :begin}] (serialize children) [{:op :end}]))
 
-(defmethod serialize-node :nest [[_ offset & children]]
-  (concat [{:op :nest, :offset offset}]
-          (serialize children)
-          [{:op :outdent}]))
+(defmethod serialize-node :nest [[_ & args]]
+  (let [[offset & children] (if (number? (first args))
+                              args
+                              (cons 2 args))]
+    (concat [{:op :nest, :offset offset}]
+            (serialize children)
+            [{:op :outdent}])))
 
 (defmethod serialize-node :align [[_ & args]]
   (let [[offset & children] (if (number? (first args))

--- a/test/fipp/engine_test.clj
+++ b/test/fipp/engine_test.clj
@@ -18,6 +18,19 @@
             {:op :text :text "C"}
             {:op :end}
             {:op :end}])))
+  (testing ":nest indent defaults to 2"
+    (is (= [{:op :nest, :offset 2}
+            {:op :text, :text "foo"}
+            {:op :outdent}]
+           (e/serialize [:nest "foo"])
+           (e/serialize [:nest 2 "foo"]))))
+  (testing ":align offset defaults to 0"
+    (is (= [{:op :align, :offset 0}
+            {:op :text, :text "foo"}
+            {:op :outdent}]
+           (e/serialize [:align "foo"])
+           (e/serialize [:align 0 "foo"]))))
+
   ;;TODO test seq expansion
   )
 


### PR DESCRIPTION
In `primitives.md` it's stated that `indent` is optional in `:nest` nodes, and should default to 2. I've altered the code to make this true, and added tests for this + the default `offset` value of 0 for `:align` nodes.