### PR TITLE
Don't emit a nil node when an ellipsis is not required

### DIFF
--- a/src/fipp/edn.cljc
+++ b/src/fipp/edn.cljc
@@ -16,7 +16,7 @@
              "#")
         ellipsis (when (and print-length (seq (drop print-length xs)))
                    [:span sep "..."])]
-    [:group open [:align ys ellipsis] close]))
+    [:group open (cond-> [:align ys] ellipsis (conj ellipsis)) close]))
 
 (defrecord EdnPrinter [symbols print-meta print-length print-level]
 
@@ -88,13 +88,17 @@
 
   )
 
+(defn edn-printer
+  ([] (edn-printer {}))
+  ([options] (let [defaults {:symbols {}
+                             :print-length *print-length*
+                             :print-level *print-level*
+                             :print-meta *print-meta*}]
+               (map->EdnPrinter (merge defaults options)))))
+
 (defn pprint
   ([x] (pprint x {}))
   ([x options]
-   (let [defaults {:symbols {}
-                   :print-length *print-length*
-                   :print-level *print-level*
-                   :print-meta *print-meta*}
-         printer (map->EdnPrinter (merge defaults options))]
+   (let [printer (edn-printer options)]
      (binding [*print-meta* false]
        (pprint-document (visit printer x) options)))))

--- a/test/fipp/edn_test.clj
+++ b/test/fipp/edn_test.clj
@@ -1,7 +1,8 @@
 (ns fipp.edn-test
   (:use [clojure.test])
   (:require [clojure.string :as str]
-            [fipp.edn :refer [pprint]]))
+            [fipp.edn :refer [edn-printer pprint]]
+            [fipp.visit :refer [visit]]))
 
 (defrecord Person [first-name last-name])
 
@@ -151,6 +152,12 @@
     (is (= (with-out-str (pprint #{#{#{#{}}}} {:print-level 3}))
            "#{#{#{#{#}}}}\n")))
   )
+
+(deftest print-length-ellipsis
+  (is (= (visit (edn-printer) [0 1])
+         '[:group "[" [:align ([:text "0"] :line [:text "1"])] "]"]))
+  (is (= (visit (edn-printer {:print-length 1}) [0 1])
+         '[:group "[" [:align ([:text "0"]) [:span :line "..."]] "]"])))
 
 (comment
 


### PR DESCRIPTION
Nothing in the spec mentions `nil` nodes, and they pass through the `serialize` algorithm fine, but I think the correct behaviour should be to emit nothing if no ellipsis is required.