### PR TITLE
remove cljs symbol conflict

### DIFF
--- a/src/fipp/visit.cljc
+++ b/src/fipp/visit.cljc
@@ -1,5 +1,6 @@
 (ns fipp.visit
-  "Convert to and visit edn structures.")
+  "Convert to and visit edn structures."
+  #?(:cljs (:refer-clojure :exclude [char?])))
 
 ;;;TODO Stablize public interface
 


### PR DESCRIPTION
When I use fipp from clojurescript, I get a compile warning:

```
WARNING: char? already refers to: cljs.core/char? being replaced by: fipp.visit/char? at line 34 target/cljsbuild/dev/out/fipp/visit.cljc
```

This PR fixes that.