### PR TITLE
Add exclusion for new `clojure.core/boolean?` var

### DIFF
--- a/src/fipp/visit.cljc
+++ b/src/fipp/visit.cljc
@@ -1,5 +1,6 @@
 (ns fipp.visit
   "Convert to and visit edn structures."
+  (:refer-clojure :exclude [boolean?])
   #?(:cljs (:refer-clojure :exclude [char?])))
 
 ;;;TODO Stablize public interface

--- a/src/fipp/visit.cljc
+++ b/src/fipp/visit.cljc
@@ -1,7 +1,7 @@
 (ns fipp.visit
   "Convert to and visit edn structures."
-  (:refer-clojure :exclude [boolean?])
-  #?(:cljs (:refer-clojure :exclude [char?])))
+  #?(:clj  (:refer-clojure :exclude [boolean?])
+     :cljs (:refer-clojure :exclude [boolean? char?])))
 
 ;;;TODO Stablize public interface
 


### PR DESCRIPTION
Clojure 1.9 adds several new predicate functions to `clojure.core`, including `boolean?`. Compiling Fipp with the 1.9.0-alpha7 prints this warning:
```
WARNING: boolean? already refers to: #'clojure.core/boolean? in namespace: fipp.visit, being replaced by: #'fipp.visit/boolean?
```
Excluding `boolean?` removes the warning.