### PR TITLE
Visit Eductions as sequences

### DIFF
--- a/src/fipp/visit.cljc
+++ b/src/fipp/visit.cljc
@@ -40,6 +40,11 @@
    :clj (defn regexp? [x]
           (instance? java.util.regex.Pattern x)))
 
+(defn eduction? [x]
+  (instance? #?(:clj  clojure.core.Eduction
+                :cljs Eduction)
+    x))
+
 (defn visit*
   "Visits objects, ignoring metadata."
   [visitor x]
@@ -60,6 +65,7 @@
     (tagged-literal? x) (visit-tagged visitor x)
     (var? x) (visit-var visitor x)
     (regexp? x) (visit-pattern visitor x)
+    (eduction? x) (recur visitor (sequence x))
     :else (visit-unknown visitor x)))
 
 (defn visit [visitor x]


### PR DESCRIPTION
Without a change like the one in this PR, Eductions (non-pretty) print as sequences, but in Fipp, it goes down a path that prints the object.

```
user=> (def x (eduction (map identity) (range 20)))
#'user/x
user=> x
(0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19)
user=> (require '[fipp.edn :refer (pprint) :rename {pprint fipp}])
nil
user=> (fipp x {:width 10})
#object[clojure.core.Eduction
        "0x77cf277b"
        "clojure.core.Eduction@77cf277b"]
nil
```

The change simply detects this situation during visiting and converts via `sequence`, thus producing:

```
user=> (fipp x {:width 10})
(0
 1
 2
 3
 4
 5
 6
 7
 8
 9
 10
 11
 12
 13
 14
 15
 16
 17
 18
 19)
nil
```

A similar, thing occurs with ClojureScript.

It is not clear at all to me if this is the right place or approach to address something like this, or whether it would be more appropriate for it to go into something like the cases handled in `fipp.ednize`, for example, so feel free to take this PR as inspiration (or reject it of course, if there is a reason not do pretty-print `Eduction` instances as sequences).

FWIW, I'm soaking a similar change downstream in Planck to see if anything breaks when trying this: https://github.com/mfikes/planck/commit/363db3edd2b23305c513154242b4c72d9f5a22cb