### PR TITLE
Allow fipp to operate independently of core print options

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ The available options are:
 
 - `:width` defaults to `70`.
 - `:writer` defaults to `clojure.core/*out*` (Clojure only).
+- `:print-fn` defaults to `cljs.core/*print-fn*` (ClojureScript only).
 - `:print-length` behaves as and defaults to `clojure.core/*print-length*`.
 - `:print-level` behaves as and defaults to `clojure.core/*print-level*`.
 - `:print-meta` behaves as and defaults to `clojure.core/*print-meta*`.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ evaluation pretty prints in color.
 The available options are:
 
 - `:width` defaults to `70`.
+- `:writer` defaults to `clojure.core/*out*` (Clojure only).
 - `:print-length` behaves as and defaults to `clojure.core/*print-length*`.
 - `:print-level` behaves as and defaults to `clojure.core/*print-level*`.
 - `:print-meta` behaves as and defaults to `clojure.core/*print-meta*`.

--- a/project.clj
+++ b/project.clj
@@ -6,6 +6,7 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/core.rrb-vector "0.0.13"]]
   :profiles {:dev {:dependencies [[criterium "0.4.3"]
-                                  [org.clojure/clojurescript "1.9.854"]]}}
+                                  [org.clojure/clojurescript "1.9.854"]
+                                  [javax.xml.bind/jaxb-api "2.3.1"]]}}
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"
                                      :sign-releases false}]])

--- a/src/fipp/edn.cljc
+++ b/src/fipp/edn.cljc
@@ -66,7 +66,7 @@
     (pretty-coll this "#{" x :line "}" visit))
 
   (visit-tagged [this {:keys [tag form]}]
-    [:group "#" (pr-str tag)
+    [:group "#" (str tag)
             (when (or (and print-meta (meta form))
                       (not (coll? form)))
               " ")

--- a/src/fipp/edn.cljc
+++ b/src/fipp/edn.cljc
@@ -35,10 +35,12 @@
     [:text (str x)])
 
   (visit-string [this x]
-    [:text (pr-str x)])
+    [:text (binding [*print-readably* true]
+             (pr-str x))])
 
   (visit-character [this x]
-    [:text (pr-str x)])
+    [:text (binding [*print-readably* true]
+             (pr-str x))])
 
   (visit-symbol [this x]
     [:text (str x)])

--- a/src/fipp/edn.cljc
+++ b/src/fipp/edn.cljc
@@ -47,7 +47,7 @@
     [:text (str x)])
 
   (visit-number [this x]
-    [:text (pr-str x)])
+    [:text (str x)])
 
   (visit-seq [this x]
     (if-let [pretty (symbols (first x))]

--- a/src/fipp/engine.cljc
+++ b/src/fipp/engine.cljc
@@ -2,7 +2,8 @@
   "See: Oleg Kiselyov, Simon Peyton-Jones, and Amr Sabry
   Lazy v. Yield: Incremental, Linear Pretty-printing"
   (:require [clojure.string :as s]
-            [fipp.deque :as deque]))
+            [fipp.deque :as deque])
+  #?(:clj (:import (java.io Writer))))
 
 
 ;;; Serialize document into a stream
@@ -231,18 +232,30 @@
          )))))
 
 
+(defn print-fns
+  [options]
+  #?(:clj (let [{:keys [^Writer writer] :or {writer *out*}} options]
+            {:print #(.write writer ^String %)
+             :println (fn []
+                        (binding [*out* writer]
+                          (println)))})
+     :cljs {:print print
+            :println println}))
+
+
 (defn pprint-document
   ([document]
    (pprint-document document))
   ([document options]
-   (let [options (merge {:width 70} options)]
+   (let [options (merge {:width 70} options)
+         {:keys [print println]} (print-fns options)]
      (->> (serialize document)
           (eduction
             annotate-rights
             (annotate-begins options)
             (format-nodes options))
-          (run! print)))
-   (println)))
+          (run! print))
+     (println))))
 
 
 (comment

--- a/src/fipp/engine.cljc
+++ b/src/fipp/engine.cljc
@@ -248,7 +248,7 @@
 
 (defn pprint-document
   ([document]
-   (pprint-document document))
+   (pprint-document document {}))
   ([document options]
    (let [options (merge {:width 70} options)
          {:keys [print println]} (print-fns options)]

--- a/src/fipp/engine.cljc
+++ b/src/fipp/engine.cljc
@@ -239,8 +239,11 @@
              :println (fn []
                         (binding [*out* writer]
                           (println)))})
-     :cljs {:print print
-            :println println}))
+     :cljs (let [{:keys [print-fn] :or {print-fn *print-fn*}} options]
+             {:print print-fn
+              :println (fn []
+                         (binding [*print-fn* print-fn]
+                           (println)))})))
 
 
 (defn pprint-document

--- a/test/fipp/edn_test.cljc
+++ b/test/fipp/edn_test.cljc
@@ -113,6 +113,11 @@
            "#'clojure.core/inc\n"))
     (is (= (with-out-str (pprint #"x\?y"))
            "#\"x\\?y\"\n")))
+  #?(:clj (testing "Not affected by *print-dup* binding"
+            (is (= (with-out-str (binding [*print-dup* true]
+                                   (pprint [(Integer. 1) (Long. 2)])))
+                   (with-out-str (pprint [(Integer. 1) (Long. 2)]))
+                   "[1 2]\n"))))
   (testing ":print-length option"
     (is (= (with-out-str (pprint (range) {:print-length 3}))
            "(0 1 2 ...)\n"))

--- a/test/fipp/edn_test.cljc
+++ b/test/fipp/edn_test.cljc
@@ -118,6 +118,16 @@
                                    (pprint [(Integer. 1) (Long. 2)])))
                    (with-out-str (pprint [(Integer. 1) (Long. 2)]))
                    "[1 2]\n"))))
+  (testing "Not affected by *print-readably* binding"
+    (is (= (with-out-str (binding [*print-readably* false]
+                           (pprint ["abc"])))
+           (with-out-str (pprint ["abc"]))
+           "[\"abc\"]\n"))
+    (is (= (with-out-str (binding [*print-readably* false]
+                           (pprint [\d \e])))
+           (with-out-str (pprint [\d \e]))
+           #?(:clj "[\\d \\e]\n"
+              :cljs "[\"d\" \"e\"]\n"))))
   (testing ":print-length option"
     (is (= (with-out-str (pprint (range) {:print-length 3}))
            "(0 1 2 ...)\n"))

--- a/test/fipp/engine_test.cljc
+++ b/test/fipp/engine_test.cljc
@@ -194,3 +194,28 @@
            (with-out-str
              (binding [*print-dup* true]
                (e/pprint-document doc1)))))))
+
+#?(:cljs (deftest print-fn-test
+           (testing ":print-fn option works"
+             (let [res (volatile! "")]
+               (e/pprint-document doc1 {:print-fn #(vswap! res str %)})
+               (is (= "A B C" @res))))
+
+           (testing ":print-fn option does not interfere with *print-fn*"
+             (let [res1 (volatile! "")
+                   res2 (volatile! "")]
+               (binding [*print-fn* #(vswap! res1 str %)]
+                 (e/pprint-document doc1 {:print-fn #(vswap! res2 str %)}))
+               (is (= "" @res1))
+               (is (= "A B C" @res2)))
+
+             (let [doc (->> (repeatedly (fn []
+                                          (print "foo")
+                                          "bar"))
+                            (take 3))
+                   res1 (volatile! "")
+                   res2 (volatile! "")]
+               (binding [*print-fn* #(vswap! res1 str %)]
+                 (e/pprint-document doc {:print-fn #(vswap! res2 str %)}))
+               (is (= "foofoofoo" @res1))
+               (is (= "barbarbar" @res2))))))


### PR DESCRIPTION
In some tooling contexts it is undesirable to read or rebind dynamic vars like `*out*`. For example, during the `print` phase of an evaluation at the REPL, using `*out*` can result in debug output being intermingled with the printed output.

This is also undesirable:

``` clojure
user> (binding [*print-dup* true]
        (fipp.edn/pprint [1 2 3]))
"""[""1"" ""2"" ""3""]"
nil
```

This PR adds a `:writer` option (defaults to `*out*`) and alters `pprint-document` to write its output directly to the writer rather than using the machinery of `print`. `println` is still called at the end to preserve the existing behaviour wrt `*flush-on-newline*`. N.B. this change seems to have a positive effect on the `:long` benchmark – from 126ms to 83ms on my machine.

For CLJS the equivalent option is `:print-fn` (defaults to `*print-fn*`), which I have added in a separate commit. `*out*` isn't generally set to anything in CLJS so I think this is the more logical extension point.

I also found that because of the use of `pr-str` in `fipp.edn`, it was possible to print invalid EDN depending on the values of `*print-dup*` / `*print-readably*`:

``` clojure
user> (binding [*print-dup* true]
        (fipp.edn/pprint (Integer. 1)))
#=(java.lang.Integer. "1")
nil
```

``` clojure
user> (binding [*print-readably* false]
        (fipp.edn/pprint ["a" "b" "c" \d \e]))
[a b c d e]
nil
```

Changes in `fipp.edn` to ensure we always print valid EDN:

* In `visit-string` and `visit-character`, bind `*print-readably*` to true when calling `pr-str`.
* In `visit-number`, just use `str`, since that's what `print-method` does (`print-dup` adds the ctor).
* In `visit-pattern`, just use `str`, since `tag` is always a symbol.

Additionally, add the `[javax.xml.bind/jaxb-api "2.3.1"]` dev-time dependency, so the CLJS tests can run on JDK11. We could also bump the CLJS version to 1.10.63 or later.