### PR TITLE
Fix fipp.engine/pprint-document’s default options

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject fipp "0.6.15"
+(defproject fipp "0.6.16"
   :description "Fast Idiomatic Pretty Printer for Clojure"
   :url "https://github.com/brandonbloom/fipp"
   :license {:name "Eclipse Public License"

--- a/src/fipp/engine.cljc
+++ b/src/fipp/engine.cljc
@@ -233,7 +233,7 @@
 
 (defn pprint-document
   ([document]
-   (pprint-document document))
+   (pprint-document document {}))
   ([document options]
    (let [options (merge {:width 70} options)]
      (->> (serialize document)


### PR DESCRIPTION
I was looking through Fipp’s recent changes and noticed that `pprint-document`’s default options were left out.