### PR TITLE
Bump core.rrb-vector to 0.0.14

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/core.rrb-vector "0.0.13"]]
+                 [org.clojure/core.rrb-vector "0.0.14"]]
   :profiles {:dev {:dependencies [[criterium "0.4.3"]
                                   [org.clojure/clojurescript "1.9.854"]]}}
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"


### PR DESCRIPTION
The just-released version 0.0.14 of core.rrb-vector fixes the issue [CRRBV-15](https://dev.clojure.org/jira/browse/CRRBV-15) that was originally reported in Fipp as https://github.com/brandonbloom/fipp/issues/42.

I've encountered this issue a couple of times – in the context of Doo and otherwise – and Fipp is usually the dependency that brings along core.rrb-vector. Hence the PR, let's get the versions of core.rrb-vector with the issue out of the dependency trees.