### PR TITLE
Work around clojure.instant bootclasspath problem

### DIFF
--- a/src/fipp/ednize.clj
+++ b/src/fipp/ednize.clj
@@ -66,17 +66,7 @@
   ;TODO reader-conditional
   ;TODO Eduction ??
 
-  java.util.Date
-  (-edn [x]
-    (let [s (format-hack #'clojure.instant/thread-local-utc-date-format x)]
-      (tagged-literal 'inst s)))
-
   ;TODO (defmethod print-method java.util.Calendar
-
-  java.sql.Timestamp
-  (-edn [x]
-    (let [s (format-hack #'clojure.instant/thread-local-utc-timestamp-format x)]
-      (tagged-literal 'inst s)))
 
   java.util.UUID
   (-edn [x]
@@ -87,6 +77,19 @@
     (tagged-literal 'clojure.lang.PersistentQueue (vec x)))
 
   )
+
+
+(when (find-ns 'clojure.instant)
+  (extend-protocol IEdn
+    java.util.Date
+    (-edn [x]
+      (let [s (format-hack (eval '(var clojure.instant/thread-local-utc-date-format)) x)]
+        (tagged-literal 'inst s)))
+
+    java.sql.Timestamp
+    (-edn [x]
+      (let [s (format-hack (eval '(var clojure.instant/thread-local-utc-timestamp-format)) x)]
+        (tagged-literal 'inst s)))))
 
 (defn record->tagged [x]
   (tagged-literal (-> x class .getName symbol) (into {} x)))


### PR DESCRIPTION
As of Java 9, certain build tools during boot will use the bootclasspath
(this includes both Lein and Boot afaik). This is a problem for
`clojure.instant` as it relies on `java.sql.Timestamp` which isn't available
on the bootclasspath.

With Fipp, this means that libraries and plugins requiring `fipp.ednize`
during the build system's operation will fail unless `LEIN_USE_BOOTCLASSPATH`
is set to no (or similar workaround for Boot).

This (admittedly somewhat evil) commit circumvents that by checking to
see if `clojure.instant` has already been loaded and only extending the
edn protocol for date/time related objects if it has been loaded.

Should resolve #60, https://github.com/venantius/ultra/issues/108 and https://github.com/venantius/ultra/issues/103