### PR TITLE
Upgrade `org.clojure/core.rrb-vector`

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/core.rrb-vector "0.1.1"]]
+                 [org.clojure/core.rrb-vector "0.1.2"]]
   ;; See <https://github.com/brandonbloom/fipp/issues/72#issuecomment-576816826>
   ;; and test code in <.github/workflows/pr.yml>.
   :eval-in-leiningen ~(= "true" (System/getenv "EVAL_IN_LEININGEN"))


### PR DESCRIPTION
Fixes a `java.lang.IllegalArgumentException: Must hint overloaded method: toArray` which can be seen under certain circumstances.