### PR TITLE
Remove format-hack in favor of java.time

### DIFF
--- a/src/fipp/ednize.clj
+++ b/src/fipp/ednize.clj
@@ -24,11 +24,6 @@
         id (format "0x%x" (System/identityHashCode o))]
     (tagged-literal 'object [cls id rep])))
 
-(defn format-hack [v x]
-  (let [local ^java.lang.ThreadLocal @v
-        fmt ^java.text.SimpleDateFormat (.get local)]
-    (.format fmt x)))
-
 (extend-protocol IEdn
 
   nil

--- a/src/fipp/ednize/instant.clj
+++ b/src/fipp/ednize/instant.clj
@@ -1,17 +1,24 @@
 (ns fipp.ednize.instant
   "Provides features that may not be available under every Clojure / JVM combination."
-  (:require [clojure.instant]
-            [fipp.ednize :refer [IEdn format-hack]])
+  (:require [fipp.ednize :refer [IEdn]])
   (:import (java.sql Timestamp)
-           (java.util Date)))
+           (java.util Date)
+           (java.time.format DateTimeFormatter)
+           (java.time ZoneId)))
+
+(set! *warn-on-reflection* true)
+
+(def date-pattern (DateTimeFormatter/ofPattern "yyyy-MM-dd'T'HH:mm:ss.SSS-00:00"))
 
 (extend-protocol IEdn
   Timestamp
   (-edn [x]
-    (let [s (format-hack #'clojure.instant/thread-local-utc-timestamp-format x)]
+    (let [dt (-> x .toInstant (.atZone (ZoneId/of "GMT")))
+          s (.format dt DateTimeFormatter/ISO_LOCAL_DATE_TIME)]
       (tagged-literal 'inst s)))
 
   Date
   (-edn [x]
-    (let [s (format-hack #'clojure.instant/thread-local-utc-date-format x)]
+    (let [dt (-> x .toInstant (.atZone (ZoneId/of "GMT")))
+          s (.format dt date-pattern)]
       (tagged-literal 'inst s))))


### PR DESCRIPTION
This addresses point 2 in https://github.com/brandonbloom/fipp/issues/81 and I think is generally in favor of relying on implementation details of clojure.