### PR TITLE
Add IOverride cache

### DIFF
--- a/src/fipp/edn.cljc
+++ b/src/fipp/edn.cljc
@@ -23,7 +23,7 @@
   [cache x]
   (let [clazz (type x)
         ret (get @cache clazz ::not-found)]
-    (if (identical? ::not-found ret)
+    (if (#?(:clj identical? :cljs keyword-identical?) ::not-found ret)
       (let [ret (satisfies? IOverride x)]
         (vswap! cache assoc clazz ret)
         ret)

--- a/src/fipp/edn.cljc
+++ b/src/fipp/edn.cljc
@@ -19,11 +19,13 @@
                    [:span sep "..."])]
     [:group open [:align ys ellipsis] close]))
 
+(def not-found #?(:clj (Object.) :cljs (js-obj)))
+
 (defn- cached-override?
   [cache x]
   (let [clazz (type x)
-        ret (get @cache clazz ::not-found)]
-    (if (#?(:clj identical? :cljs keyword-identical?) ::not-found ret)
+        ret (get @cache clazz not-found)]
+    (if (identical? not-found ret)
       (let [ret (satisfies? IOverride x)]
         (vswap! cache assoc clazz ret)
         ret)

--- a/src/fipp/edn.cljc
+++ b/src/fipp/edn.cljc
@@ -2,7 +2,7 @@
   "Provides a pretty document serializer and pprint fn for Clojure/EDN forms.
   See fipp.clojure for pretty printing Clojure code."
   (:require [clojure.string :as str]
-            [fipp.ednize :refer [edn record->tagged]]
+            [fipp.ednize :refer [edn record->tagged IOverride]]
             [fipp.visit :refer [visit visit*]]
             [fipp.engine :refer (pprint-document)]))
 
@@ -19,10 +19,22 @@
                    [:span sep "..."])]
     [:group open [:align ys ellipsis] close]))
 
-(defrecord EdnPrinter [symbols print-meta print-length print-level]
+(defn- cached-override?
+  [cache x]
+  (let [clazz (type x)
+        ret (get @cache clazz ::not-found)]
+    (if (identical? ::not-found ret)
+      (let [ret (satisfies? IOverride x)]
+        (vswap! cache assoc clazz ret)
+        ret)
+      ret)))
+
+(defrecord EdnPrinter [symbols print-meta print-length print-level cache]
 
   fipp.visit/IVisitor
 
+  (visit-override? [_ x]
+    (cached-override? cache x))
 
   (visit-unknown [this x]
     (visit this (edn x)))
@@ -96,6 +108,7 @@
   ([x] (pretty x {}))
   ([x options]
    (let [defaults {:symbols {}
+                   :cache (volatile! {})
                    :print-length *print-length*
                    :print-level *print-level*
                    :print-meta *print-meta*}

--- a/src/fipp/visit.cljc
+++ b/src/fipp/visit.cljc
@@ -1,7 +1,6 @@
 (ns fipp.visit
   "Convert to and visit edn structures."
-  (:require [fipp.util :as util]
-            [fipp.ednize :refer [override?]]))
+  (:require [fipp.util :as util]))
 
 ;;;TODO Stablize public interface
 
@@ -27,6 +26,8 @@
   (visit-var [this x])
   (visit-pattern [this x])
   (visit-record [this x])
+
+  (visit-override? [this x])
   )
 
 (defn visit*
@@ -34,7 +35,7 @@
   [visitor x]
   (cond
     (nil? x) (visit-nil visitor)
-    (override? x) (visit-unknown visitor x)
+    (visit-override? visitor x) (visit-unknown visitor x)
     (util/boolean? x) (visit-boolean visitor x)
     (string? x) (visit-string visitor x)
     (util/char? x) (visit-character visitor x)

--- a/test.sh
+++ b/test.sh
@@ -6,4 +6,4 @@ lein test
 
 java -cp $(lein classpath) clojure.main build_cljs.clj
 
-node ./out/main.js
+node --stack-size=2048 ./out/main.js

--- a/test.sh
+++ b/test.sh
@@ -6,4 +6,4 @@ lein test
 
 java -cp $(lein classpath) clojure.main build_cljs.clj
 
-node --stack-size=2048 ./out/main.js
+node --stack-size=1024 ./out/main.js


### PR DESCRIPTION
Speeds up `:long` benchmark ~2.5x and `:mixed` ~2x

Closes #87