### PR TITLE
FIX #85: Special handling for java.sql.Date

### DIFF
--- a/src/fipp/ednize/instant.clj
+++ b/src/fipp/ednize/instant.clj
@@ -19,8 +19,7 @@
 
   java.sql.Date
   (-edn [x]
-    (let [d (.toLocalDate x)
-          s (.format d DateTimeFormatter/ISO_LOCAL_DATE)]
+    (let [s (.toString x)]
       (tagged-literal 'inst s)))
 
   Date

--- a/src/fipp/ednize/instant.clj
+++ b/src/fipp/ednize/instant.clj
@@ -17,6 +17,12 @@
           s (.format dt DateTimeFormatter/ISO_LOCAL_DATE_TIME)]
       (tagged-literal 'inst s)))
 
+  java.sql.Date
+  (-edn [x]
+    (let [d (.toLocalDate x)
+          s (.format d DateTimeFormatter/ISO_LOCAL_DATE)]
+      (tagged-literal 'inst s)))
+
   Date
   (-edn [x]
     (let [dt (-> x .toInstant (.atZone (ZoneId/of "GMT")))

--- a/test/fipp/ednize_test.cljc
+++ b/test/fipp/ednize_test.cljc
@@ -29,7 +29,14 @@
         #?@(:clj [(-> java.sql.Timestamp
                       (.getConstructor (into-array Class [Long/TYPE]))
                       (.newInstance (into-array Object [0])))
-                  'inst "1970-01-01T00:00:00"]))))
+                  'inst "1970-01-01T00:00:00"])
+
+        #?@(:clj [(-> java.sql.Date
+                      (.getConstructor (into-array Class [Long/TYPE]))
+                      (.newInstance (into-array Object [0])))
+                  'inst "1970-01-01"]))))
+
+
 
   (testing "No-op for stuff that is already shallow edn."
     (are [obj] (= (edn obj) obj)

--- a/test/fipp/ednize_test.cljc
+++ b/test/fipp/ednize_test.cljc
@@ -31,9 +31,7 @@
                       (.newInstance (into-array Object [0])))
                   'inst "1970-01-01T00:00:00"])
 
-        #?@(:clj [(-> java.sql.Date
-                      (.getConstructor (into-array Class [Long/TYPE]))
-                      (.newInstance (into-array Object [0])))
+        #?@(:clj [(java.sql.Date/valueOf (java.time.LocalDate/of 1970 1 1))
                   'inst "1970-01-01"]))))
 
 


### PR DESCRIPTION
java.sql.Date is a subclass of java.util.Date but throws a runtime exception `UnsupportedOperationException` when called, because a SQL date inherently has no time information associated with it. It is just a date.

Therefore a special case is added to the protocol to support pretty printing java.sql.Date objects.